### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ Sends an api request to last.fm. Returns a json_decode()'d object of the result.
 Config
 ===
 Currently, the configuration items are stored in the class itself. You should extend the class and set the $key and $secret properties. This may (that means probably) change later.
+
+Test the API on [RapidAPI](https://rapidapi.com/package/LastFM/functions?utm_source=LastFMGitHub&utm_medium=button).


### PR DESCRIPTION
I've added a link in your README to LastFM's functions page in RapidAPI. I've done this for a few LastFM SDKs to help those who are reading the READMEs, understand and test the API before use.